### PR TITLE
Display recordings in Notebook

### DIFF
--- a/sc_kernel/kernel.py
+++ b/sc_kernel/kernel.py
@@ -97,11 +97,8 @@ class SCKernel(ProcessMetaKernel):
         :param message:
         :return:
         """
-        self.log.error(message)
         recording_paths: List[str] = self._sclang.RECORD_MATCHER_REGEX.findall(message)
-        self.log.error(f'Recording Paths: {recording_paths}')
         self.recording_paths.update(recording_paths)
-        self.log.error(f'self.record_paths: {self.recording_paths}')
         for recording_path in recording_paths:
             self.log.info(f'Found new recording: {recording_path}')
 
@@ -110,13 +107,11 @@ class SCKernel(ProcessMetaKernel):
         displayed_recordings: List[str] = []
         for finished_recording in finished_recordings:
             for recording_path in [f for f in self.recording_paths if finished_recording in f]:
+                self.log.info(f'Found finished recording: {recording_path}')
                 time.sleep(1.0)  # wait for finished writing, just in case
-                self.log.error(f'Found finished recording: {recording_path}')
                 self.Display(Audio(filename=recording_path))
                 displayed_recordings.append(recording_path)
-            else:
-                self.log.error(f'Found finished recording without captured path: {finished_recording}')
-        self.recording_paths.difference(displayed_recordings)
+        self.recording_paths.difference_update(displayed_recordings)
 
     def Write(self, message):
         self._check_for_recordings(message)


### PR DESCRIPTION
Could close #6 

Current workflow looks like this

![grafik](https://user-images.githubusercontent.com/8267062/99880068-670e7900-2c11-11eb-87f5-6c7120da36aa.png)

* start server
* change recording format to something that is displayable by a browser
* Prepare record b/c otherwise the recording path will not be captured as this will run in another thread on which we do not capture the stdout
* Start recording - we can not display the audio file here as the browsers can not display audio files that have not been written yet
* Finish recording - as the file is now fully written we can display it now

Still a bit ugly, maybe this can be abstracted a bit better through some Jupyter magic?